### PR TITLE
fix: re-enable site indexing

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -125,9 +125,6 @@ export default defineNuxtConfig({
       },
     },
   },
-  site: {
-    indexable: false,
-  },
   linkChecker: {
     enabled: false,
   },


### PR DESCRIPTION
will only index when NUXT_SITE_ENV = "production"